### PR TITLE
Return raw request JSON as an option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ typings/
 
 # MacOS
 .DS_Store
+
+package-lock.json

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -32,6 +32,7 @@ const session = async ({
     },
     body: JSON.stringify(requestBody),
   }
+  if (TokenType === 'raw_request') { return JSON.stringify(request) }
   const response = await fetch(`https://cognito-idp.${domain}.amazonaws.com`, request)
 
   if (response.status !== 200) {
@@ -192,6 +193,10 @@ module.exports.templateTags = [
           {
             displayName: "id",
             value: "id",
+          },
+          {
+            displayName: "Raw Request",
+            value: "raw_request",
           },
         ],
       },


### PR DESCRIPTION
This PR follows #11 and adds the option to return not the token but the request values so you can play along at home (or in your app or an insomnia request).

I've added package-lock.json to the .gitignore; or consider adding it to the repo.